### PR TITLE
Avoid creation of duplicate peformers

### DIFF
--- a/maps/CdaToBundle.map
+++ b/maps/CdaToBundle.map
@@ -140,7 +140,13 @@ group CdaToFhirBundle(source cda : ClinicalDocument, target fhir_bundle : Bundle
     // create relation from ServiceRequest to Patient
     fhir_serviceRequest.subject = create('Reference') as fhir_serviceRequest_subject_reference,
     fhir_serviceRequest_subject_reference.reference = reference(fhir_patient),
-    fhir_serviceRequest_subject_reference.type = 'Patient'
+    fhir_serviceRequest_subject_reference.type = 'Patient',
+
+    // PractitionerRole
+    fhir_bundle.entry as fhir_bundle_entry01,
+    fhir_bundle_entry01.resource = create('PractitionerRole') as fhir_practitionerRole,
+    fhir_practitionerRole.id = uuid() as fhir_practitionerRole_id,
+    fhir_bundle_entry01.fullUrl = append('urn:uuid:', fhir_practitionerRole_id)
 
     then {
       cda then CdaHeaderToFhirComposition(cda, fhir_composition, fhir_patient, fhir_diagnosticReport, fhir_serviceRequest, fhir_bundle) "CdaHeaderToFhirComposition";
@@ -149,7 +155,8 @@ group CdaToFhirBundle(source cda : ClinicalDocument, target fhir_bundle : Bundle
       cda.component as cda_component then {
         // ClinicalDocument.component.structuredBody
         cda_component.structuredBody as cda_structuredBody
-          then CdaBodyToFhirComposition(cda, cda_structuredBody, fhir_composition, fhir_patient, fhir_diagnosticReport, fhir_bundle);
+        
+          then CdaToPractitionerRole(cda, fhir_practitionerRole, fhir_bundle), CdaBodyToFhirComposition(cda, cda_structuredBody, fhir_composition, fhir_practitionerRole, fhir_patient, fhir_diagnosticReport, fhir_bundle);
       };
       // cda.component as component then {
       //   component.structuredBody as structuredBody then {
@@ -796,7 +803,7 @@ group CdaEncompassingEncounterToFhirEncounter(source cda_encompassingEncounter :
 
 // _________________________ Section Level Templates _________________________
 
-group CdaBodyToFhirComposition(source cda: ClinicalDocument, source cda_structuredBody: StructuredBody, target fhir_composition: Composition, target fhir_patient: Patient, target fhir_diagnosticReport: DiagnosticReport, target fhir_bundle: Bundle) {
+group CdaBodyToFhirComposition(source cda: ClinicalDocument, source cda_structuredBody: StructuredBody, target fhir_composition: Composition, target fhir_practitionerRole: PractitionerRole, target fhir_patient: Patient, target fhir_diagnosticReport: DiagnosticReport, target fhir_bundle: Bundle) {
   cda_structuredBody.component as cda_component then {
     // simple sections
     cda_component.section as cda_section where code.where(code='BRIEFT' and codeSystem='1.2.40.0.34.5.40') // Brieftext
@@ -817,8 +824,33 @@ group CdaBodyToFhirComposition(source cda: ClinicalDocument, source cda_structur
 
     // Laboratory Specialty Section
     cda_component.section as cda_section where templateId.where(root='1.2.40.0.34.6.0.11.2.102' or root='1.3.6.1.4.1.19376.1.3.3.2.1')
-      -> fhir_composition.section as fhir_section then CdaLaboratorySpecialtySectionToFhirSection(cda, cda_section, fhir_section, fhir_patient, fhir_diagnosticReport, fhir_bundle);
+    -> fhir_composition.section as fhir_section then CdaLaboratorySpecialtySectionToFhirSection(cda, cda_section, fhir_section, fhir_practitionerRole, fhir_patient, fhir_diagnosticReport, fhir_bundle);
   };
+}
+
+group CdaToPractitionerRole(source cda: ClinicalDocument, target fhir_practitionerRole: PractitionerRole, target fhir_bundle: Bundle) {
+    // performer has been specified in documentationOf[1]serviceEvent.performer
+    cda where cda.documentationOf[0].serviceEvent.performer.exists() then {
+        // ClinicalDocument.documentationOf
+        cda.documentationOf first as cda_documentationOf then {
+            // ClinicalDocument.documentationOf.serviceEvent
+            cda_documentationOf.serviceEvent as cda_documentationOf_serviceEvent then {
+                cda_documentationOf_serviceEvent.performer as cda_documentationOf_serviceEvent_performer then {
+                    // observation.performer.assignedEntity
+                    cda_documentationOf_serviceEvent_performer.assignedEntity as cda_performer_assignedEntity
+                        then CdaAssignedEntityToFhirPractitionerRole(cda_performer_assignedEntity, fhir_practitionerRole, fhir_bundle);
+                };
+            };
+        };
+    } "CdaDocumentationOfServiceEventPerformerExists";
+    // no performer has been specified in documentationOf[1]serviceEvent.performer. as a result the ClinicalDocument.authors will be taken as performer
+    cda where cda.documentationOf[0].serviceEvent.performer.exists().not() then {
+        // ClinicalDocument.author (as person)
+        cda.author as cda_author where $this.assignedAuthor.assignedPerson.exists() then
+            // create the PractitionerRole in order to capture the author.functionCode
+            CdaAuthorToFhirPractitionerRole(cda_author, fhir_practitionerRole, fhir_bundle)
+            "CdaAuthorToObservationPerformer";
+    } "CdaDocumentationOfServiceEventPerformerExistsNot";
 }
 
 group CdaSectionToFhirSection(source cda_section: Section, target fhir_section, target fhir_bundle: Bundle) {
@@ -1007,7 +1039,7 @@ group CdaSpecimenSectionToFhirSection(source cda_section: Section, target fhir_s
   };
 }
 
-group CdaLaboratorySpecialtySectionToFhirSection (source cda: ClinicalDocument, source cda_section: Section, target fhir_section, target fhir_patient: Patient, target fhir_diagnosticReport: DiagnosticReport, target fhir_bundle: Bundle) extends CdaSectionToFhirSection {
+group CdaLaboratorySpecialtySectionToFhirSection (source cda: ClinicalDocument, source cda_section: Section, target fhir_section, target fhir_practitionerRole: PractitionerRole, target fhir_patient: Patient, target fhir_diagnosticReport: DiagnosticReport, target fhir_bundle: Bundle) extends CdaSectionToFhirSection {
   // section.entry (Laboratory Report Data Processing Entry)
   cda_section.entry as cda_section_entry then {
     // section.entry.act
@@ -1081,41 +1113,30 @@ group CdaLaboratorySpecialtySectionToFhirSection (source cda: ClinicalDocument, 
               fhir_observation_effective_extenstion_code.value = 'not-applicable'
                "CdaEffectiveTimeExistsNotToFhirObservationEffective";
 
-
             // organizer.performer if existent in organizer
             cda_laboratory_battery_organizer.performer as cda_laboratory_battery_organizer_performer
-              where cda_laboratory_battery_organizer.performer.exists()
-              then CdaPerformerToFhirObservationPerformer(cda_laboratory_battery_organizer_performer, fhir_observation, fhir_bundle)
-              "CdaBatteryOrganizerPerformerToFhirObservationPerformer";
+                where cda_laboratory_battery_organizer.performer.exists()
+                then CdaPerformerToFhirObservationPerformer(cda_laboratory_battery_organizer_performer, fhir_observation, fhir_bundle)
+                "CdaBatteryOrganizerPerformerToFhirObservationPerformer";
             // organizer.performer if not existent in organizer
             cda_laboratory_battery_organizer where cda_laboratory_battery_organizer.performer.exists().not() then {
-              // performer has been specified in documentationOf[1]serviceEvent.performer
-              cda where cda.documentationOf[0].serviceEvent.performer.exists() then {
-                // ClinicalDocument.documentationOf
-                cda.documentationOf first as cda_documentationOf then {
-                  // ClinicalDocument.documentationOf.serviceEvent
-                  cda_documentationOf.serviceEvent as cda_documentationOf_serviceEvent then {
-                    cda_documentationOf_serviceEvent.performer as cda_documentationOf_serviceEvent_performer
-                    then CdaPerformerToFhirObservationPerformer(cda_documentationOf_serviceEvent_performer, fhir_observation, fhir_bundle)
-                    "CdaServiceEventPerformerToFhirObservationPerformer";
-                  };
-                };
-              } "CdaDocumentationOfServiceEventPerformerExists";
-              // no performer has been specified in documentationOf[1]serviceEvent.performer. as a result the ClinicalDocument.authors will be taken as performer
-              cda where cda.documentationOf[0].serviceEvent.performer.exists().not() then {
-                // ClinicalDocument.author (as person)
-                cda.author as cda_author where $this.assignedAuthor.assignedPerson.exists() ->
-                  // create the PractitionerRole in order to capture the author.functionCode
-                  fhir_bundle.entry as fhir_bundle_entry,
-                  fhir_bundle_entry.resource = create('PractitionerRole') as fhir_practitionerRole,
-                  fhir_practitionerRole.id = uuid() as fhir_practitionerRole_id,
-                  fhir_bundle_entry.fullUrl = append('urn:uuid:', fhir_practitionerRole_id),
-                  fhir_observation.performer = create('Reference') as fhir_observation_performer_reference,
-                  fhir_observation_performer_reference.reference = reference(fhir_practitionerRole),
-                  fhir_observation_performer_reference.type = 'PractitionerRole' then
-                  CdaAuthorToFhirPractitionerRole(cda_author, fhir_practitionerRole, fhir_bundle)
-                  "CdaAuthorToObservationPerformer";
-              } "CdaDocumentationOfServiceEventPerformerExistsNot";
+                cda where cda.documentationOf[0].serviceEvent.performer.exists() then {
+                    // ClinicalDocument.documentationOf
+                    cda.documentationOf first as cda_documentationOf then {
+                        // ClinicalDocument.documentationOf.serviceEvent
+                        cda_documentationOf.serviceEvent as cda_documentationOf_serviceEvent then {
+                            cda_documentationOf_serviceEvent.performer as cda_documentationOf_serviceEvent_performer then {
+                                // observation.performer.time - it is assumed that only @value occurs and no interval
+                                cda_documentationOf_serviceEvent_performer.time -> fhir_observation.issued;
+                            };
+                        };
+                    };
+                } "CdaDocumentationOfServiceEventPerformerExists";
+                cda ->
+                    fhir_observation.performer = create('Reference') as fhir_observation_performer_reference,
+                    fhir_observation_performer_reference.reference = reference(fhir_practitionerRole),
+                    fhir_observation_performer_reference.type = 'PractitionerRole'
+                "CdaBatteryOrganizerPerformerExistsNotRole";
             } "CdaBatteryOrganizerPerformerExistsNot";
 
             // organizer.component (Laboratory Observation)
@@ -1129,7 +1150,7 @@ group CdaLaboratorySpecialtySectionToFhirSection (source cda: ClinicalDocument, 
                 fhir_observation.hasMember = create('Reference') as fhir_observation_hasMember_reference,
                 fhir_observation_hasMember_reference.reference = reference(fhir_laboratory_observation),
                 fhir_observation_hasMember_reference.type = 'Observation'
-                then CdaLaboratoryObservationToFhirObservation(cda, cda_laboratory_observation, fhir_laboratory_observation, fhir_patient, fhir_bundle);
+                then CdaLaboratoryObservationToFhirObservation(cda, cda_laboratory_observation, fhir_laboratory_observation, fhir_practitionerRole, fhir_patient, fhir_bundle);
             };
           };
       };
@@ -1161,7 +1182,7 @@ group CdaObservationToFhirObservation(source cda_observation : CDAObservation, t
 
 }
 
-group CdaLaboratoryObservationToFhirObservation(source cda: ClinicalDocument, source cda_laboratory_observation : CDAObservation, target fhir_observation : Observation, target fhir_patient: Patient, target fhir_bundle: Bundle) {
+group CdaLaboratoryObservationToFhirObservation(source cda: ClinicalDocument, source cda_laboratory_observation : CDAObservation, target fhir_observation : Observation, target fhir_practitionerRole: PractitionerRole, target fhir_patient: Patient, target fhir_bundle: Bundle) {
   cda_laboratory_observation ->
     fhir_observation.meta as fhir_observation_meta,
     fhir_observation_meta.profile = 'http://hl7.eu/fhir/laboratory/StructureDefinition/Observation-resultslab-eu-lab'
@@ -1233,33 +1254,25 @@ group CdaLaboratoryObservationToFhirObservation(source cda: ClinicalDocument, so
     "CdaObservationPerformerToFhirObservationPerformer";
   // observation.performer if not existent in observation
   cda_laboratory_observation where cda_laboratory_observation.performer.exists().not() then {
-    // performer has been specified in documentationOf[1]serviceEvent.performer
+
     cda where cda.documentationOf[0].serviceEvent.performer.exists() then {
-      // ClinicalDocument.documentationOf
-      cda.documentationOf first as cda_documentationOf then {
-        // ClinicalDocument.documentationOf.serviceEvent
-        cda_documentationOf.serviceEvent as cda_documentationOf_serviceEvent then {
-          cda_documentationOf_serviceEvent.performer as cda_documentationOf_serviceEvent_performer
-          then CdaPerformerToFhirObservationPerformer(cda_documentationOf_serviceEvent_performer, fhir_observation, fhir_bundle)
-          "CdaServiceEventPerformerToFhirObservationPerformer";
+        // ClinicalDocument.documentationOf
+        cda.documentationOf first as cda_documentationOf then {
+            // ClinicalDocument.documentationOf.serviceEvent
+            cda_documentationOf.serviceEvent as cda_documentationOf_serviceEvent then {
+                cda_documentationOf_serviceEvent.performer as cda_documentationOf_serviceEvent_performer then {
+                    // observation.performer.time - it is assumed that only @value occurs and no interval
+                    cda_documentationOf_serviceEvent_performer.time  -> fhir_observation.issued "AAA";
+                };
+            };
         };
-      };
     } "CdaDocumentationOfServiceEventPerformerExists";
-    // no performer has been specified in documentationOf[1]serviceEvent.performer. as a result the ClinicalDocument.authors will be taken as performer
-    cda where cda.documentationOf[0].serviceEvent.performer.exists().not() then {
-      // ClinicalDocument.author (as person)
-      cda.author as cda_author where $this.assignedAuthor.assignedPerson.exists() ->
-        // create the PractitionerRole in order to capture the author.functionCode
-        fhir_bundle.entry as fhir_bundle_entry,
-        fhir_bundle_entry.resource = create('PractitionerRole') as fhir_practitionerRole,
-        fhir_practitionerRole.id = uuid() as fhir_practitionerRole_id,
-        fhir_bundle_entry.fullUrl = append('urn:uuid:', fhir_practitionerRole_id),
+    cda ->
         fhir_observation.performer = create('Reference') as fhir_observation_performer_reference,
         fhir_observation_performer_reference.reference = reference(fhir_practitionerRole),
-        fhir_observation_performer_reference.type = 'PractitionerRole' then
-        CdaAuthorToFhirPractitionerRole(cda_author, fhir_practitionerRole, fhir_bundle)
-        "CdaAuthorToObservationPerformer";
-    } "CdaDocumentationOfServiceEventPerformerExistsNot";
+        fhir_observation_performer_reference.type = 'PractitionerRole'
+    "CdaObservationPerformerExistsNotRole";
+
   } "CdaObservationPerformerExistsNot";
 
   // observation.participant

--- a/maps/CdaToBundle.map
+++ b/maps/CdaToBundle.map
@@ -557,7 +557,7 @@ group CdaPatientRoleToFhirPatient(source cda_patientRole : PatientRole, target f
     cda_patient.birthTime as cda_patient_birthTime where (cda_patient.birthTime.value.length() > 10) -> fhir_patient.birthDate as fhir_patient_birthDate,
       fhir_patient_birthDate.extension as extension,
       extension.url = 'http://hl7.org/fhir/StructureDefinition/patient-birthTime',
-      extension.value = (cda_patient_birthTime.value.toDateTime()) "CdaPatientBirthTimeToFhirPatientBirthTimeExtension";
+      extension.value = create('dateTime') as fhir_patient_birthTime_dateTime then TSDateTime(cda_patient_birthTime, fhir_patient_birthTime_dateTime) "CdaPatientBirthTimeToFhirPatientBirthTimeExtension";
     // patient.deceasedInd
     cda_patient.deceasedInd as cda_patient_deceasedInd where cda_patient.deceasedTime.empty() -> fhir_patient.deceased = create('boolean') as fhir_patient_deceased then BL(cda_patient_deceasedInd, fhir_patient_deceased) "CdaPatientDeceasedIndToFhirPatientDeceasedBoolean";
     // patient.deceasedTime

--- a/maps/CdaToBundle.map
+++ b/maps/CdaToBundle.map
@@ -54,13 +54,13 @@ uses "http://hl7.org/fhir/cda/StructureDefinition/Performer2" alias Performer as
 uses "http://hl7.org/fhir/StructureDefinition/Bundle" alias Bundle as target
 uses "http://hl7.org/fhir/StructureDefinition/Composition" alias Composition as target
 uses "http://hl7.org/fhir/StructureDefinition/Patient" alias Patient as target
-uses "http://hl7.org/fhir/StructureDefinition/Person" alias Patient as target
+uses "http://hl7.org/fhir/StructureDefinition/Person" alias Person as target
 uses "http://hl7.org/fhir/StructureDefinition/Practitioner" alias Practitioner as target
 uses "http://hl7.org/fhir/StructureDefinition/PractitionerRole" alias PractitionerRole as target
 uses "http://hl7.org/fhir/StructureDefinition/Organization" alias Organization as target
 uses "http://hl7.org/fhir/StructureDefinition/DiagnosticReport" alias DiagnosticReport as target
 uses "http://hl7.org/fhir/StructureDefinition/ServiceRequest" alias ServiceRequest as target
-uses "http://hl7.org/fhir/StructureDefinition/Observation" alias ServiceRequest as target
+uses "http://hl7.org/fhir/StructureDefinition/Observation" alias Observation as target
 
 imports "http://hl7.at/fhir/HL7ATCoreProfiles/4.0.1/StructureMap/at-cda-to-fhir-types"
 
@@ -498,7 +498,7 @@ group CdaPatientRoleToFhirPatient(source cda_patientRole : PatientRole, target f
     cda_patientRole_id then II(cda_patientRole_id, fhir_patient_identifier) "CdaIdToFhirIdentifier";
 
     // setting identifier.type.coding according to profile for Social Security Number
-    cda_patientRole_id where (cda_patientRole_id.root = "1.2.40.0.10.1.4.3.1") ->
+    cda_patientRole_id where (cda_patientRole_id.root = '1.2.40.0.10.1.4.3.1') ->
       // according to profile no or this fixed value is required
       fhir_patient_identifier.assigner as assigner,
       assigner.display = 'Dachverband der österreichischen Sozialversicherungsträger',
@@ -511,7 +511,7 @@ group CdaPatientRoleToFhirPatient(source cda_patientRole : PatientRole, target f
       "FhirPatientIdentifierTypeCodingSS";
 
     // setting identifier.type.coding according to profile for National unique individual identifier
-    cda_patientRole_id where (cda_patientRole_id.root = "1.2.40.0.10.2.1.1.149") ->
+    cda_patientRole_id where (cda_patientRole_id.root = '1.2.40.0.10.2.1.1.149') ->
       // according to profile no or this fixed value is required
       fhir_patient_identifier.assigner as assigner,
       assigner.display = 'Bundesministerium für Inneres',
@@ -550,7 +550,7 @@ group CdaPatientRoleToFhirPatient(source cda_patientRole : PatientRole, target f
     cda_patient.birthTime as cda_patient_birthTime where (cda_patient.birthTime.value.length() > 10) -> fhir_patient.birthDate as fhir_patient_birthDate,
       fhir_patient_birthDate.extension as extension,
       extension.url = 'http://hl7.org/fhir/StructureDefinition/patient-birthTime',
-      extension.value = (cda_patient_birthTime.value) "CdaPatientBirthTimeToFhirPatientBirthTimeExtension";
+      extension.value = (cda_patient_birthTime.value.toDateTime()) "CdaPatientBirthTimeToFhirPatientBirthTimeExtension";
     // patient.deceasedInd
     cda_patient.deceasedInd as cda_patient_deceasedInd where cda_patient.deceasedTime.empty() -> fhir_patient.deceased = create('boolean') as fhir_patient_deceased then BL(cda_patient_deceasedInd, fhir_patient_deceased) "CdaPatientDeceasedIndToFhirPatientDeceasedBoolean";
     // patient.deceasedTime
@@ -1152,7 +1152,7 @@ group CdaLaboratorySpecialtySectionToFhirSection (source cda: ClinicalDocument, 
 
 group CdaObservationToFhirObservation(source cda_observation : CDAObservation, target fhir_observation : Observation) {
   // observation.id
-  cda_laboratory_observation.id -> fhir_observation.identifier;
+  cda_observation.id -> fhir_observation.identifier;
   // observation.code
   // to be defined in derived versions of this group
   // observation.text


### PR DESCRIPTION
Could we avoid creating a performer for each observation like this?

The code can probably still be improved, but it seems to do the job. Also includes fixes from #1 