### PR TITLE
Remove formatCode, change target for practiceSettingCode

### DIFF
--- a/maps/CdaToBundle.4.map
+++ b/maps/CdaToBundle.4.map
@@ -235,7 +235,7 @@ group CdaHeaderToFhirComposition(source cda : ClinicalDocument, target fhir_comp
   
   // ClinicalDocument.hl7at:formatCode: will not be mapped. (see AG ELGA CDA2FHIR 2025-11-17)
   // ClinicalDocument.hl7at:practiceSettingCode
-  cda.practiceSettingCode as cda_practiceSettingCode -> fhir_composition.category = create('CodeableConcept') as fhir_composition_category then CDCodeableConcept(cda_practiceSettingCode, fhir_composition_category);
+  cda.practiceSettingCode -> fhir_composition.category;
  
   // ClinicalDocument.effectiveTime
   cda.effectiveTime -> fhir_composition.date;

--- a/maps/CdaToBundle.4.map
+++ b/maps/CdaToBundle.4.map
@@ -233,17 +233,9 @@ group CdaHeaderToFhirComposition(source cda : ClinicalDocument, target fhir_comp
     fhir_composition_terminologyDate_extension.url = 'http://hl7.at/fhir/HL7ATCoreProfiles/4.0.1/StructureDefinition/at-core-ext-composition-terminologyDate',
     fhir_composition_terminologyDate_extension.value = create('dateTime') as fhir_composition_terminologyDate_dateTime then TSDate(cda_terminologyDate, fhir_composition_terminologyDate_dateTime);
   
-  // ClinicalDocument.hl7at:formatCode
-  cda.formatCode as cda_formatCode -> 
-    fhir_composition.extension as fhir_composition_formatCode_extension,
-    fhir_composition_formatCode_extension.url = 'http://hl7.at/fhir/HL7ATCoreProfiles/4.0.1/StructureDefinition/at-core-ext-composition-formatCode',
-    fhir_composition_formatCode_extension.value = create('CodeableConcept') as fhir_composition_formatCode_codeableConcept then CDCodeableConcept(cda_formatCode, fhir_composition_formatCode_codeableConcept);
-
+  // ClinicalDocument.hl7at:formatCode: will not be mapped. (see AG ELGA CDA2FHIR 2025-11-17)
   // ClinicalDocument.hl7at:practiceSettingCode
-  cda.practiceSettingCode as cda_practiceSettingCode -> 
-    fhir_composition.extension as fhir_composition_practicesetting_extension,
-    fhir_composition_practicesetting_extension.url = 'http://hl7.at/fhir/HL7ATCoreProfiles/4.0.1/StructureDefinition/at-core-ext-composition-practiceSettingCode',
-    fhir_composition_practicesetting_extension.value = create('CodeableConcept') as fhir_composition_practicesetting_codeableConcept then CDCodeableConcept(cda_practiceSettingCode, fhir_composition_practicesetting_codeableConcept);
+  cda.practiceSettingCode as cda_practiceSettingCode -> fhir_composition.category = create('CodeableConcept') as fhir_composition_category then CDCodeableConcept(cda_practiceSettingCode, fhir_composition_category);
  
   // ClinicalDocument.effectiveTime
   cda.effectiveTime -> fhir_composition.date;


### PR DESCRIPTION
- **FormatCode** → Mapping is not necessary because the **FHIR2CDA mapping** `formatCode` will always reference the **latest CDA-IG version**.

- **Change** `practiceSettingCode` from `Composition.extension` to `Composition.category`

- **ToDo:**  
  Check **MyHealth@EU Laboratory Report – Composition** to see if a slice would be applicable for `practiceSettingCode` → `Composition.category`
