### PR TITLE
Add sample, add coding in absentReason

### DIFF
--- a/input/Lab_Allgemeiner_Laborbefund.xml
+++ b/input/Lab_Allgemeiner_Laborbefund.xml
@@ -10625,6 +10625,23 @@
                                             <value xsi:type="CD" code="255599008" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Incomplete (qualifier value)"/>
                                         </observation>
                                     </component>
+                                    <component typeCode="COMP">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <!-- templateId für Laboratory Observation Entry -->
+                                            <templateId root="1.2.40.0.34.6.0.11.3.27"/>
+                                            <!-- templateId für IHE PalM TF3 Rev.10, 6.3.4.13 Laboratory Observation -->
+                                            <templateId root="1.3.6.1.4.1.19376.1.3.1.6"/>
+                                            <id extension="OBS-4-7" root="1.2.40.0.34.99.4613.122082.1.3.5"/>
+                                            <code code="2668-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Noradrenal.Urinexkr."/>
+                                            <text>
+                                                <reference value="#OBS-4-6"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <effectiveTime nullFlavor="UNK"/>
+                                            <!-- Analyse nicht ausgeführt, weil "Insufficient Sample" -->
+                                            <value xsi:type="CD" code="281268007" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Insufficient sample (finding)"/>
+                                        </observation>
+                                    </component>
                                 </organizer>
                             </entryRelationship>
 

--- a/maps/CdaToBundle.4.map
+++ b/maps/CdaToBundle.4.map
@@ -1959,12 +1959,16 @@ group CdaLaboratoryObservationToFhirObservation(source cda: ClinicalDocument, so
   
   // observation.value.codoe = 281268007 - Insufficient sample (finding)
    cda_laboratory_observation
-    where cda_laboratory_observation.value.exists(code='281268007' and codeSystem='2.16.840.1.113883.6.96') ->
-      fhir_observation.status = 'cancelled',
-      fhir_observation.dataAbsentReason as fhir_observation_dataAbsentReason,
-      fhir_observation_dataAbsentReason.coding as fhir_observation_dataAbsentReason_coding,
-      fhir_observation_dataAbsentReason_coding.code = 'not-performed',
-      fhir_observation_dataAbsentReason_coding.system = 'http://terminology.hl7.org/CodeSystem/data-absent-reason'
+    where cda_laboratory_observation.value.exists(code='281268007' and codeSystem='2.16.840.1.113883.6.96') then {
+        cda_laboratory_observation.value as cda_laboratory_observation_value ->
+          fhir_observation.status = 'cancelled',
+          fhir_observation.dataAbsentReason as fhir_observation_dataAbsentReason,
+          fhir_observation_dataAbsentReason.coding as fhir_observation_dataAbsentReason_coding_1,
+          fhir_observation_dataAbsentReason_coding_1.code = 'not-performed',
+          fhir_observation_dataAbsentReason_coding_1.system = 'http://terminology.hl7.org/CodeSystem/data-absent-reason',
+          fhir_observation_dataAbsentReason.coding as fhir_observation_dataAbsentReason_coding_2 then 
+          CDCoding(cda_laboratory_observation_value, fhir_observation_dataAbsentReason_coding_2);
+      }
       "CdaIncompleteObservationToFhirObservationStatus";
 
   // observation.value.codoe = 255599008 -   Incomplete (qualifier value)


### PR DESCRIPTION
I have now added the original code from the CDA to the dataAbsentReason as second code along with not-performed.