### PR TITLE
Disable display coverage

### DIFF
--- a/.github/workflows/convert-and-validate.yml
+++ b/.github/workflows/convert-and-validate.yml
@@ -48,12 +48,6 @@ jobs:
         run: |
           python scripts/combine_coverage.py
 
-      - name: display coverage
-        uses: orgoro/coverage@v3.2
-        with:
-          coverageFile: coverage/coverage.xml
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: upload
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/convert-and-validate.yml
+++ b/.github/workflows/convert-and-validate.yml
@@ -48,6 +48,12 @@ jobs:
         run: |
           python scripts/combine_coverage.py
 
+      # - name: display coverage
+      #   uses: orgoro/coverage@v3.2
+      #   with:
+      #     coverageFile: coverage/coverage.xml
+      #     token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: upload
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Currently, there are problems when the coverage is supposed to be displayed in PRs from forks. As such, the coverage will be disabled. Still, the coverage is part of the pipeline and can be inspected as part of the artifacts.