### PR TITLE
Add nullFlavor check for author.time before mapping to Provenance.occurred

### DIFF
--- a/input/eimpf/eImpf-Kompletter_Immunisierungsstatus.xml
+++ b/input/eimpf/eImpf-Kompletter_Immunisierungsstatus.xml
@@ -317,7 +317,7 @@
                             <!-- Medizinisch verantwortliche Person -->
                             <author>
                                 <!-- Zeitpunkt der Freigabe -->
-                                <time value="20160617122000+0200"/>
+                                <time nullFlavor="UNK"/>
                                 <assignedAuthor>
                                     <id root="1.2.40.0.34.99.4613.3.3" extension="232311"/>
                                     <code code="100" displayName="Ärztin/Arzt für Allgemeinmedizin"

--- a/maps/CdaEimpfToFhirBundle.4.map
+++ b/maps/CdaEimpfToFhirBundle.4.map
@@ -938,7 +938,7 @@ group CdaPerformerToFhirProvenance(source cda_performer: CdaPerformer2, target f
 group CdaAuthorPersonToFhirProvenance(source cda_author: CdaAuthor, target fhir_provenance: FhirProvenance, target fhir_practitionerRole: FhirPractitionerRole, target fhir_bundle: FhirBundle){
   // author/time -> Provenance.occurredDateTime
   // see CdaAuthorToFhirPractitionerAndPractitionerRole which is also used for ClinicalDocument/author: https://github.com/HL7Austria/CDA2FHIR/issues/159
-  cda_author.time as cda_participant_time -> 
+  cda_author.time as cda_participant_time where ($this.nullFlavor.exists().not()) -> 
     fhir_provenance.occurred = create('dateTime') as fhir_provenance_occurred then 
       TSDateTime(cda_participant_time, fhir_provenance_occurred) "CdaPerformerTimeToFhirProvenanceOccurred";
 
@@ -967,7 +967,7 @@ group CdaAuthorPersonToFhirProvenance(source cda_author: CdaAuthor, target fhir_
 group CdaAuthorDeviceToFhirProvenance(source cda_author: CdaAuthor, target fhir_provenance: FhirProvenance, target fhir_bundle: FhirBundle){
   // author/time -> Provenance.occurredDateTime
   // see CdaAuthorToFhirPractitionerAndPractitionerRole which is also used for ClinicalDocument/author: https://github.com/HL7Austria/CDA2FHIR/issues/159
-  cda_author.time as cda_participant_time -> 
+  cda_author.time as cda_participant_time where ($this.nullFlavor.exists().not()) -> 
     fhir_provenance.occurred = create('dateTime') as fhir_provenance_occurred then 
       TSDateTime(cda_participant_time, fhir_provenance_occurred) "CdaPerformerTimeToFhirProvenanceOccurred";
 


### PR DESCRIPTION
`CdaAuthorPersonToFhirProvenance` and `CdaAuthorDeviceToFhirProvenance` currently map `author.time` directly to `fhir_provenance.occurred` without verifying whether a `nullFlavor` is present.

According to the [specification](https://art-decor.org/ad/#/elgaimpf-/rules/templates/1.2.40.0.34.6.0.11.9.8/2025-10-21T10:44:38), `author.time` may include a `nullFlavor="UNK"`.

This PR adds a `nullFlavor` check for `author.time` before mapping it to `fhir_provenance.occurred`.

closes #254  