### PR TITLE
Refactor originalText/textReference mapping into reusable group

### DIFF
--- a/maps/CdaEimpfToFhirBundle.4.map
+++ b/maps/CdaEimpfToFhirBundle.4.map
@@ -14,6 +14,7 @@ uses "http://hl7.org/cda/stds/core/StructureDefinition/Material" alias CdaMateri
 uses "http://hl7.org/cda/stds/core/StructureDefinition/Participant2" alias CdaParticipant2 as source
 uses "http://hl7.org/cda/stds/core/StructureDefinition/Performer2" alias CdaPerformer2 as source
 uses "http://hl7.org/cda/stds/core/StructureDefinition/Author" alias CdaAuthor as source
+uses "http://hl7.org/cda/stds/core/StructureDefinition/Act" alias CdaAct as source 
 
 uses "http://hl7.org/fhir/4.3/StructureDefinition/Bundle" alias FhirBundle as target
 uses "http://hl7.org/fhir/4.3/StructureDefinition/Composition" alias FhirComposition as target
@@ -23,6 +24,7 @@ uses "http://hl7.org/fhir/4.3/StructureDefinition/ImmunizationRecommendation" al
 uses "http://hl7.org/fhir/4.3/StructureDefinition/CodeableConcept" alias FhirCodeableConcept as target
 uses "http://hl7.org/fhir/4.3/StructureDefinition/Provenance" alias FhirProvenance as target
 uses "http://hl7.org/fhir/4.3/StructureDefinition/PractitionerRole" alias FhirPractitionerRole as target
+uses "http://hl7.org/fhir/4.3/StructureDefinition/String" alias FhirString as target 
 
 imports "http://hl7.at/fhir/HL7ATCoreProfiles/4.0.1/StructureMap/at-cda-to-fhir-types"
 
@@ -664,40 +666,8 @@ group CdaEimpfSubstanceAdministrationToFhirImmunizationRecommendation(source cda
     // substanceAdministration/entryRelationship (Comment Entry)
     cda_substanceAdministration.entryRelationship as cda_substanceAdministration_entryRelationship where ($this.act.templateId.where(root='1.2.40.0.34.6.0.11.3.17')) then {
       // substanceAdministration/entryRelationship/act
-      cda_substanceAdministration_entryRelationship.act as cda_act then {
-        // substanceAdministration/entryRelationship/act/text
-        cda_act.text as cda_act_text then {
-          // substanceAdministration/entryRelationship/act/text/reference
-          cda_act_text.reference as cda_act_text_reference then {
-            cda_section.text as cda_section_text then {
-              // substanceAdministration/entryRelationship/act/text/reference/@value -> ImmunizationRecommendation.recommendation.description
-              cda_act_text_reference.value as cda_act_text_reference_value -> 
-                // Create Narrative (same datatype as in Composition.section.text)
-                create('Narrative') as fhir_narrative, 
-                // section/text -> Narrative.div
-                fhir_narrative.div = cda_section_text as fhir_narrative_div,
-                
-                // Create string
-                create('string') as fhir_string,
-                // Convert test_div to a FHIR string
-                fhir_string = (fhir_narrative_div),
-
-                // Create substring from the ID (identified by cda_act_text_reference_value) till the end of fhir_string
-                create('string') as fhir_substring_01,
-                // cda_act_text_reference_value.substring(1) = removing '#' from reference/@value (e.g. '#commentRef-1' becomes 'commentRef-1')
-                // fhir_string.indexOf(cda_act_text_reference_value.substring(1)) = the position of the ID within section/text
-                fhir_substring_01 = (fhir_string.substring(fhir_string.indexOf(cda_act_text_reference_value.substring(1)))),
-
-                // Create a substring from the first occurrence of > character till the end of fhir_substring_01
-                create('string') as fhir_substring_02,
-                fhir_substring_02 = (fhir_substring_01.substring(fhir_substring_01.indexOf('>') + 1)),
-
-                // Create a substring from the start till the first occurrence of < character
-                fhir_immunizationRecommendation_recommendation.description = (fhir_substring_02.substring(0, fhir_substring_02.indexOf('<')));
-            };
-          };
-        };
-      };
+      cda_substanceAdministration_entryRelationship.act as cda_act -> 
+        fhir_immunizationRecommendation_recommendation.description as fhir_description then CdaNarrativeTextToFhirString(cda_act, cda_section_text, fhir_description); 
     };
 
     // substanceAdministration/reference/externalDocument -> Immunization.identifier
@@ -744,6 +714,41 @@ group CdaEimpfSubstanceAdministrationToFhirImmunizationRecommendation(source cda
       }; 
     }; 
   };
+}
+
+group CdaNarrativeTextToFhirString(source cda_act: CdaAct, source cda_section: CdaSection, target fhir_string: FhirString){
+  // substanceAdministration/entryRelationship/act/text
+        cda_act.text as cda_act_text then {
+          // substanceAdministration/entryRelationship/act/text/reference
+          cda_act_text.reference as cda_act_text_reference then {
+            cda_section.text as cda_section_text then {
+              // substanceAdministration/entryRelationship/act/text/reference/@value -> ImmunizationRecommendation.recommendation.description
+              cda_act_text_reference.value as cda_act_text_reference_value -> 
+                // Create Narrative (same datatype as in Composition.section.text)
+                create('Narrative') as fhir_narrative, 
+                // section/text -> Narrative.div
+                fhir_narrative.div = cda_section_text as fhir_narrative_div,
+                
+                // Create string
+                create('string') as fhir_string,
+                // Convert test_div to a FHIR string
+                fhir_string = (fhir_narrative_div),
+
+                // Create substring from the ID (identified by cda_act_text_reference_value) till the end of fhir_string
+                create('string') as fhir_substring_01,
+                // cda_act_text_reference_value.substring(1) = removing '#' from reference/@value (e.g. '#commentRef-1' becomes 'commentRef-1')
+                // fhir_string.indexOf(cda_act_text_reference_value.substring(1)) = the position of the ID within section/text
+                fhir_substring_01 = (fhir_string.substring(fhir_string.indexOf(cda_act_text_reference_value.substring(1)))),
+
+                // Create a substring from the first occurrence of > character till the end of fhir_substring_01
+                create('string') as fhir_substring_02,
+                fhir_substring_02 = (fhir_substring_01.substring(fhir_substring_01.indexOf('>') + 1)),
+
+                // Create a substring from the start till the first occurrence of < character
+                fhir_immunizationRecommendation_recommendation.description = (fhir_substring_02.substring(0, fhir_substring_02.indexOf('<')));
+            };
+          };
+        };
 }
 
 group CdaVaccineCodeToFhirVaccineCode(source cda_manufacturedMaterial: CdaMaterial, target fhir_vaccineCode: FhirCodeableConcept) {

--- a/maps/CdaEimpfToFhirBundle.4.map
+++ b/maps/CdaEimpfToFhirBundle.4.map
@@ -24,7 +24,7 @@ uses "http://hl7.org/fhir/4.3/StructureDefinition/ImmunizationRecommendation" al
 uses "http://hl7.org/fhir/4.3/StructureDefinition/CodeableConcept" alias FhirCodeableConcept as target
 uses "http://hl7.org/fhir/4.3/StructureDefinition/Provenance" alias FhirProvenance as target
 uses "http://hl7.org/fhir/4.3/StructureDefinition/PractitionerRole" alias FhirPractitionerRole as target
-uses "http://hl7.org/fhir/4.3/StructureDefinition/String" alias FhirString as target 
+
 
 imports "http://hl7.at/fhir/HL7ATCoreProfiles/4.0.1/StructureMap/at-cda-to-fhir-types"
 
@@ -667,7 +667,7 @@ group CdaEimpfSubstanceAdministrationToFhirImmunizationRecommendation(source cda
     cda_substanceAdministration.entryRelationship as cda_substanceAdministration_entryRelationship where ($this.act.templateId.where(root='1.2.40.0.34.6.0.11.3.17')) then {
       // substanceAdministration/entryRelationship/act
       cda_substanceAdministration_entryRelationship.act as cda_act -> 
-        fhir_immunizationRecommendation_recommendation.description as fhir_description then CdaNarrativeTextToFhirString(cda_act, cda_section_text, fhir_description); 
+        fhir_immunizationRecommendation_recommendation.description as fhir_description then CdaNarrativeTextToFhirString(cda_act, cda_section, fhir_description); 
     };
 
     // substanceAdministration/reference/externalDocument -> Immunization.identifier
@@ -715,40 +715,42 @@ group CdaEimpfSubstanceAdministrationToFhirImmunizationRecommendation(source cda
     }; 
   };
 }
-
-group CdaNarrativeTextToFhirString(source cda_act: CdaAct, source cda_section: CdaSection, target fhir_string: FhirString){
+// ToDo
+// Look for proper naming convention for target_string -> maybe fhir_description would be better. 
+// (Naming conv. does not influence functionality of this group)
+group CdaNarrativeTextToFhirString(source cda_act: CdaAct, source cda_section: CdaSection, target target_string: string){
   // substanceAdministration/entryRelationship/act/text
-        cda_act.text as cda_act_text then {
-          // substanceAdministration/entryRelationship/act/text/reference
-          cda_act_text.reference as cda_act_text_reference then {
-            cda_section.text as cda_section_text then {
-              // substanceAdministration/entryRelationship/act/text/reference/@value -> ImmunizationRecommendation.recommendation.description
-              cda_act_text_reference.value as cda_act_text_reference_value -> 
-                // Create Narrative (same datatype as in Composition.section.text)
-                create('Narrative') as fhir_narrative, 
-                // section/text -> Narrative.div
-                fhir_narrative.div = cda_section_text as fhir_narrative_div,
-                
-                // Create string
-                create('string') as fhir_string,
-                // Convert test_div to a FHIR string
-                fhir_string = (fhir_narrative_div),
+  cda_act.text as cda_act_text then {
+    // substanceAdministration/entryRelationship/act/text/reference
+    cda_act_text.reference as cda_act_text_reference then {
+      cda_section.text as cda_section_text then {
+        // substanceAdministration/entryRelationship/act/text/reference/@value -> ImmunizationRecommendation.recommendation.description
+        cda_act_text_reference.value as cda_act_text_reference_value -> 
+          // Create Narrative (same datatype as in Composition.section.text)
+          create('Narrative') as fhir_narrative, 
+          // section/text -> Narrative.div
+          fhir_narrative.div = cda_section_text as fhir_narrative_div,
+          
+          // Create string
+          create('string') as fhir_string,
+          // Convert test_div to a FHIR string
+          fhir_string = (fhir_narrative_div),
 
-                // Create substring from the ID (identified by cda_act_text_reference_value) till the end of fhir_string
-                create('string') as fhir_substring_01,
-                // cda_act_text_reference_value.substring(1) = removing '#' from reference/@value (e.g. '#commentRef-1' becomes 'commentRef-1')
-                // fhir_string.indexOf(cda_act_text_reference_value.substring(1)) = the position of the ID within section/text
-                fhir_substring_01 = (fhir_string.substring(fhir_string.indexOf(cda_act_text_reference_value.substring(1)))),
+          // Create substring from the ID (identified by cda_act_text_reference_value) till the end of fhir_string
+          create('string') as fhir_substring_01,
+          // cda_act_text_reference_value.substring(1) = removing '#' from reference/@value (e.g. '#commentRef-1' becomes 'commentRef-1')
+          // fhir_string.indexOf(cda_act_text_reference_value.substring(1)) = the position of the ID within section/text
+          fhir_substring_01 = (fhir_string.substring(fhir_string.indexOf(cda_act_text_reference_value.substring(1)))),
 
-                // Create a substring from the first occurrence of > character till the end of fhir_substring_01
-                create('string') as fhir_substring_02,
-                fhir_substring_02 = (fhir_substring_01.substring(fhir_substring_01.indexOf('>') + 1)),
+          // Create a substring from the first occurrence of > character till the end of fhir_substring_01
+          create('string') as fhir_substring_02,
+          fhir_substring_02 = (fhir_substring_01.substring(fhir_substring_01.indexOf('>') + 1)),
 
-                // Create a substring from the start till the first occurrence of < character
-                fhir_immunizationRecommendation_recommendation.description = (fhir_substring_02.substring(0, fhir_substring_02.indexOf('<')));
-            };
-          };
-        };
+          // Create a substring from the start till the first occurrence of < character
+          target_string.value = (fhir_substring_02.substring(0, fhir_substring_02.indexOf('<')));
+      };
+    };
+  };
 }
 
 group CdaVaccineCodeToFhirVaccineCode(source cda_manufacturedMaterial: CdaMaterial, target fhir_vaccineCode: FhirCodeableConcept) {

--- a/maps/CdaEimpfToFhirBundle.4.map
+++ b/maps/CdaEimpfToFhirBundle.4.map
@@ -715,43 +715,6 @@ group CdaEimpfSubstanceAdministrationToFhirImmunizationRecommendation(source cda
     }; 
   };
 }
-// ToDo
-// Look for proper naming convention for target_string -> maybe fhir_description would be better. 
-// (Naming conv. does not influence functionality of this group)
-group CdaNarrativeTextToFhirString(source cda_act: CdaAct, source cda_section: CdaSection, target target_string: string){
-  // substanceAdministration/entryRelationship/act/text
-  cda_act.text as cda_act_text then {
-    // substanceAdministration/entryRelationship/act/text/reference
-    cda_act_text.reference as cda_act_text_reference then {
-      cda_section.text as cda_section_text then {
-        // substanceAdministration/entryRelationship/act/text/reference/@value -> ImmunizationRecommendation.recommendation.description
-        cda_act_text_reference.value as cda_act_text_reference_value -> 
-          // Create Narrative (same datatype as in Composition.section.text)
-          create('Narrative') as fhir_narrative, 
-          // section/text -> Narrative.div
-          fhir_narrative.div = cda_section_text as fhir_narrative_div,
-          
-          // Create string
-          create('string') as fhir_string,
-          // Convert test_div to a FHIR string
-          fhir_string = (fhir_narrative_div),
-
-          // Create substring from the ID (identified by cda_act_text_reference_value) till the end of fhir_string
-          create('string') as fhir_substring_01,
-          // cda_act_text_reference_value.substring(1) = removing '#' from reference/@value (e.g. '#commentRef-1' becomes 'commentRef-1')
-          // fhir_string.indexOf(cda_act_text_reference_value.substring(1)) = the position of the ID within section/text
-          fhir_substring_01 = (fhir_string.substring(fhir_string.indexOf(cda_act_text_reference_value.substring(1)))),
-
-          // Create a substring from the first occurrence of > character till the end of fhir_substring_01
-          create('string') as fhir_substring_02,
-          fhir_substring_02 = (fhir_substring_01.substring(fhir_substring_01.indexOf('>') + 1)),
-
-          // Create a substring from the start till the first occurrence of < character
-          target_string.value = (fhir_substring_02.substring(0, fhir_substring_02.indexOf('<')));
-      };
-    };
-  };
-}
 
 group CdaVaccineCodeToFhirVaccineCode(source cda_manufacturedMaterial: CdaMaterial, target fhir_vaccineCode: FhirCodeableConcept) {
   // substanceAdministration/consumable/manufacturedProduct/manufacturedMaterial/code -> fhir_vaccineCode

--- a/maps/CdaEimpfToFhirBundle.4.map
+++ b/maps/CdaEimpfToFhirBundle.4.map
@@ -14,7 +14,7 @@ uses "http://hl7.org/cda/stds/core/StructureDefinition/Material" alias CdaMateri
 uses "http://hl7.org/cda/stds/core/StructureDefinition/Participant2" alias CdaParticipant2 as source
 uses "http://hl7.org/cda/stds/core/StructureDefinition/Performer2" alias CdaPerformer2 as source
 uses "http://hl7.org/cda/stds/core/StructureDefinition/Author" alias CdaAuthor as source
-uses "http://hl7.org/cda/stds/core/StructureDefinition/Act" alias CdaAct as source 
+
 
 uses "http://hl7.org/fhir/4.3/StructureDefinition/Bundle" alias FhirBundle as target
 uses "http://hl7.org/fhir/4.3/StructureDefinition/Composition" alias FhirComposition as target

--- a/maps/CdaToFhirBundle.4.map
+++ b/maps/CdaToFhirBundle.4.map
@@ -1343,3 +1343,41 @@ group CdaParticipantToFhirPractitionerRole(source cda_participant: Participant2,
         };
     };
 }
+
+// ToDo
+// Look for proper naming convention for target_string -> maybe fhir_description would be better. 
+// (Naming conv. does not influence functionality of this group)
+group CdaNarrativeTextToFhirString(source cda_act: CdaAct, source cda_section: CdaSection, target target_string: string){
+  // substanceAdministration/entryRelationship/act/text
+  cda_act.text as cda_act_text then {
+    // substanceAdministration/entryRelationship/act/text/reference
+    cda_act_text.reference as cda_act_text_reference then {
+      cda_section.text as cda_section_text then {
+        // substanceAdministration/entryRelationship/act/text/reference/@value -> ImmunizationRecommendation.recommendation.description
+        cda_act_text_reference.value as cda_act_text_reference_value -> 
+          // Create Narrative (same datatype as in Composition.section.text)
+          create('Narrative') as fhir_narrative, 
+          // section/text -> Narrative.div
+          fhir_narrative.div = cda_section_text as fhir_narrative_div,
+          
+          // Create string
+          create('string') as fhir_string,
+          // Convert test_div to a FHIR string
+          fhir_string = (fhir_narrative_div),
+
+          // Create substring from the ID (identified by cda_act_text_reference_value) till the end of fhir_string
+          create('string') as fhir_substring_01,
+          // cda_act_text_reference_value.substring(1) = removing '#' from reference/@value (e.g. '#commentRef-1' becomes 'commentRef-1')
+          // fhir_string.indexOf(cda_act_text_reference_value.substring(1)) = the position of the ID within section/text
+          fhir_substring_01 = (fhir_string.substring(fhir_string.indexOf(cda_act_text_reference_value.substring(1)))),
+
+          // Create a substring from the first occurrence of > character till the end of fhir_substring_01
+          create('string') as fhir_substring_02,
+          fhir_substring_02 = (fhir_substring_01.substring(fhir_substring_01.indexOf('>') + 1)),
+
+          // Create a substring from the start till the first occurrence of < character
+          target_string.value = (fhir_substring_02.substring(0, fhir_substring_02.indexOf('<')));
+      };
+    };
+  };
+}

--- a/maps/CdaToFhirBundle.4.map
+++ b/maps/CdaToFhirBundle.4.map
@@ -1347,7 +1347,7 @@ group CdaParticipantToFhirPractitionerRole(source cda_participant: Participant2,
 // ToDo
 // Look for proper naming convention for target_string -> maybe fhir_description would be better. 
 // (Naming conv. does not influence functionality of this group)
-group CdaNarrativeTextToFhirString(source cda_act: CdaAct, source cda_section: CdaSection, target target_string: string){
+group CdaNarrativeTextToFhirString(source cda_act: Act, source cda_section: Section, target target_string: string){
   // substanceAdministration/entryRelationship/act/text
   cda_act.text as cda_act_text then {
     // substanceAdministration/entryRelationship/act/text/reference


### PR DESCRIPTION
@

## Summary

- Extracts Comment Entry narrative-text resolution into a new abstract group `CdaNarrativeTextToFhirString`

- Group takes `(Act, Section, target string)` so any resource can receive the resolved text

- Replaces the inline logic in `CdaEimpfToFhirBundle.4.map` with a call to the new group

  

## Why

The same `#commentRef-N` → narrative text lookup appears in n places in eImpf and would lead to duplicatoin of code in all .maps Extracting it as a reusable group keeps the substring/indexOf parsing in one place.

  

## Test plan

- [x] Regenerate Python via malac-hd and confirm no `String` AttributeError
- [x] Spot-check that `ImmunizationRecommendation.recommendation.description` is populated identically to before

@