### PR TITLE
Make release latest by default

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,6 @@ jobs:
             --title "$TAG" \
             --generate-notes \
             --notes-start-tag "${{ github.event.inputs.previous_release_tag }}" \
-            --latest=false
 
           BODY=$(gh release view "$TAG" --json body -q .body)
           URL=$(gh release view "$TAG" --json url -q .url)


### PR DESCRIPTION
For whatever reason the option `latest=false` didn't work. As spending more time into this tiny detail doesn't seem to be reasonable new releases are set to be latest by default.