### PR TITLE
Use MyHealth@EU profile canonicals

### DIFF
--- a/maps/CdaLabToFhirBundle.4.map
+++ b/maps/CdaLabToFhirBundle.4.map
@@ -8150,9 +8150,9 @@ group CdaLabHeaderToFhir(source cda: ClinicalDocument, target fhir_composition: 
           // Check that meta.profile url is correct
           fhir_bundle where ($this.meta.profile = 'http://fhir.ehdsi.eu/laboratory/StructureDefinition/Bundle-lab-myhealtheu') ->
             fhir_practitionerRole.meta as fhir_practitionerRole_meta,
-            fhir_practitionerRole_meta.profile = 'http://hl7.eu/fhir/base/StructureDefinition/practitionerRole-eu-core',
+            fhir_practitionerRole_meta.profile = 'http://fhir.ehdsi.eu/core/StructureDefinition/practitionerRole-myhealtheu-core',
             fhir_practitioner.meta as fhir_practitioner_meta,
-            fhir_practitioner_meta.profile = 'http://hl7.eu/fhir/base/StructureDefinition/practitioner-eu-core'
+            fhir_practitioner_meta.profile = 'http://fhir.ehdsi.eu/core/StructureDefinition/practitioner-myhealtheu-core'
             "FhirPractitionerAndPractitionerRoleProfile";
 
             // Organization
@@ -9098,7 +9098,7 @@ group CdaLaboratoryObservationToFhirObservation(source cda: ClinicalDocument, so
         // Check that meta.profile url is correct
         fhir_bundle where ($this.meta.profile = 'http://fhir.ehdsi.eu/laboratory/StructureDefinition/Bundle-lab-myhealtheu') ->
           fhir_practitioner.meta as fhir_practitioner_meta,
-          fhir_practitioner_meta.profile = 'http://hl7.eu/fhir/base/StructureDefinition/practitioner-eu-core'
+          fhir_practitioner_meta.profile = 'http://fhir.ehdsi.eu/core/StructureDefinition/practitioner-myhealtheu-core'
           "AuthorFhirPractitionerProfile";
         
         // participantRole.id -> practitioner.identifier

--- a/maps/CdaToFhirBundle.4.map
+++ b/maps/CdaToFhirBundle.4.map
@@ -902,9 +902,9 @@ group CdaAuthorToFhirPractitionerAndPractitionerRole(source cda_author : Author,
     // Check that meta.profile url is correct
     fhir_bundle where ($this.meta.profile = 'http://fhir.ehdsi.eu/laboratory/StructureDefinition/Bundle-lab-myhealtheu') ->
       fhir_practitionerRole.meta as fhir_practitionerRole_meta,
-      fhir_practitionerRole_meta.profile = 'http://hl7.eu/fhir/base/StructureDefinition/practitionerRole-eu-core',
+      fhir_practitionerRole_meta.profile = 'http://fhir.ehdsi.eu/core/StructureDefinition/practitionerRole-myhealtheu-core',
       fhir_practitioner.meta as fhir_practitioner_meta,
-      fhir_practitioner_meta.profile = 'http://hl7.eu/fhir/base/StructureDefinition/practitioner-eu-core'
+      fhir_practitioner_meta.profile = 'http://fhir.ehdsi.eu/core/StructureDefinition/practitioner-myhealtheu-core'
       "AuthorFhirPractitionerAndPractitionerRoleProfile";
 
     // ClinicalDocument.author.time
@@ -1201,9 +1201,9 @@ group CdaAssignedEntityToFhirPractitionerRole(source cda_assignedEntity : Assign
       // Check that meta.profile url is correct
       fhir_bundle where ($this.meta.profile = 'http://fhir.ehdsi.eu/laboratory/StructureDefinition/Bundle-lab-myhealtheu') ->
         fhir_practitionerRole.meta as fhir_practitionerRole_meta,
-        fhir_practitionerRole_meta.profile = 'http://hl7.eu/fhir/base/StructureDefinition/practitionerRole-eu-core',
+        fhir_practitionerRole_meta.profile = 'http://fhir.ehdsi.eu/core/StructureDefinition/practitionerRole-myhealtheu-core',
         fhir_practitioner.meta as fhir_practitioner_meta,
-        fhir_practitioner_meta.profile = 'http://hl7.eu/fhir/base/StructureDefinition/practitioner-eu-core'
+        fhir_practitioner_meta.profile = 'http://fhir.ehdsi.eu/core/StructureDefinition/practitioner-myhealtheu-core'
         "FhirPractitionerAndPractitionerRoleProfile";
       // assignedEntity.id
       cda_assignedEntity.id where (nullFlavor.exists().not()) -> fhir_practitioner.identifier;
@@ -1256,9 +1256,9 @@ group CdaAssociatedEntityToFhirPractitionerRole(source cda_associatedEntity : As
       // Check that meta.profile url is correct
       fhir_bundle where ($this.meta.profile = 'http://fhir.ehdsi.eu/laboratory/StructureDefinition/Bundle-lab-myhealtheu') ->
         fhir_practitionerRole.meta as fhir_practitionerRole_meta,
-        fhir_practitionerRole_meta.profile = 'http://hl7.eu/fhir/base/StructureDefinition/practitionerRole-eu-core',
+        fhir_practitionerRole_meta.profile = 'http://fhir.ehdsi.eu/core/StructureDefinition/practitionerRole-myhealtheu-core',
         fhir_practitioner.meta as fhir_practitioner_meta,                                                                                                           
-        fhir_practitioner_meta.profile = 'http://hl7.eu/fhir/base/StructureDefinition/practitioner-eu-core'
+        fhir_practitioner_meta.profile = 'http://fhir.ehdsi.eu/core/StructureDefinition/practitioner-myhealtheu-core'
         "FhirPractitionerAndPractitionerRoleProfile";
 
       // associatedEntity.id
@@ -1336,9 +1336,9 @@ group CdaParticipantToFhirPractitionerRole(source cda_participant: Participant2,
         // Check that meta.profile url is correct
         fhir_bundle where ($this.meta.profile = 'http://fhir.ehdsi.eu/laboratory/StructureDefinition/Bundle-lab-myhealtheu') ->
           fhir_practitionerRole.meta as fhir_practitionerRole_meta,
-          fhir_practitionerRole_meta.profile = 'http://hl7.eu/fhir/base/StructureDefinition/practitionerRole-eu-core',
+          fhir_practitionerRole_meta.profile = 'http://fhir.ehdsi.eu/core/StructureDefinition/practitionerRole-myhealtheu-core',
           fhir_practitioner.meta as fhir_practitioner_meta,                                                                                                           
-          fhir_practitioner_meta.profile = 'http://hl7.eu/fhir/base/StructureDefinition/practitioner-eu-core'
+          fhir_practitioner_meta.profile = 'http://fhir.ehdsi.eu/core/StructureDefinition/practitioner-myhealtheu-core'
           "FhirPractitionerAndPractitionerRoleProfile";
 
         // participantRole/id ->  Practitioner.identifier

--- a/maps/CdaToFhirTypes.4.map
+++ b/maps/CdaToFhirTypes.4.map
@@ -889,7 +889,7 @@ group CdaOrganizationCompilationToFhirOrganization(source cda_organization: CdaO
 group CdaOrganizationCompilationToFhirOrganizationWithBundle(source cda_organization: CdaOrganization, source fhir_bundle: Bundle, target fhir_organization : Organization) {
   fhir_bundle where ($this.meta.profile = 'http://fhir.ehdsi.eu/laboratory/StructureDefinition/Bundle-lab-myhealtheu') ->
     fhir_organization.meta as fhir_organization_meta,
-    fhir_organization_meta.profile = 'http://hl7.eu/fhir/base/StructureDefinition/organization-eu-core'
+    fhir_organization_meta.profile = 'http://fhir.ehdsi.eu/core/StructureDefinition/organization-myhealtheu-core'
     "FhirOrganizationProfile";
   
   cda_organization.id where (nullFlavor.exists().not()) -> fhir_organization.identifier;
@@ -905,7 +905,7 @@ group CdaOrganizationCompilationToFhirOrganizationWithBundle(source cda_organiza
 group CdaCustodianOrganizationToFhirOrganizationWithBundle(source cda_organization: CdaCustodianOrganization, source fhir_bundle: Bundle, target fhir_organization : Organization) {
   fhir_bundle where ($this.meta.profile = 'http://fhir.ehdsi.eu/laboratory/StructureDefinition/Bundle-lab-myhealtheu') ->
     fhir_organization.meta as fhir_organization_meta,
-    fhir_organization_meta.profile = 'http://hl7.eu/fhir/base/StructureDefinition/organization-eu-core'
+    fhir_organization_meta.profile = 'http://fhir.ehdsi.eu/core/StructureDefinition/organization-myhealtheu-core'
     "FhirOrganizationProfile";
   
   // ClinicalDocument.custodian.assignedCustodian.representedCustodianOrganization.id


### PR DESCRIPTION
These profiles also conform to HL7EU or the
FHIR base profiles. As such, it is save to use the MyHealth@EU profile canonicals in the mapping.